### PR TITLE
FEC-11180 nanoCDNHost set to empty string

### DIFF
--- a/Example/playkit-ios-broadpeak.xcodeproj/project.pbxproj
+++ b/Example/playkit-ios-broadpeak.xcodeproj/project.pbxproj
@@ -288,6 +288,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-playkit-ios-broadpeak_Example/Pods-playkit-ios-broadpeak_Example-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/AFNetworking/AFNetworking.framework",
 				"${BUILT_PRODUCTS_DIR}/KalturaNetKit/KalturaNetKit.framework",
 				"${BUILT_PRODUCTS_DIR}/KalturaPlayer/KalturaPlayer.framework",
 				"${BUILT_PRODUCTS_DIR}/ObjcExceptionBridging/ObjcExceptionBridging.framework",
@@ -297,12 +298,14 @@
 				"${BUILT_PRODUCTS_DIR}/PlayKitProviders/PlayKitProviders.framework",
 				"${BUILT_PRODUCTS_DIR}/PlayKitUtils/PlayKitUtils.framework",
 				"${PODS_ROOT}/SmartLib-v3/Pod/SmartLib.framework",
+				"${PODS_ROOT}/SmartLib-v3/Pod/kaltura/SmartLibKaltura.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftyJSON/SwiftyJSON.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftyXMLParser/SwiftyXMLParser.framework",
 				"${BUILT_PRODUCTS_DIR}/XCGLogger/XCGLogger.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AFNetworking.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KalturaNetKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KalturaPlayer.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ObjcExceptionBridging.framework",
@@ -312,6 +315,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PlayKitProviders.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PlayKitUtils.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SmartLib.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SmartLibKaltura.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyXMLParser.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/XCGLogger.framework",

--- a/Example/playkit-ios-broadpeak/PlayerViewController.swift
+++ b/Example/playkit-ios-broadpeak/PlayerViewController.swift
@@ -106,7 +106,7 @@ class PlayerViewController: UIViewController {
         
         let bpConfig = BroadpeakConfig()
         bpConfig.analyticsAddress = ""
-        bpConfig.nanoCDNHost = "cdnapisec.kaltura.com"
+        bpConfig.nanoCDNHost = ""
         bpConfig.broadpeakDomainNames = "*"
         
         playerOptions.pluginConfig = PluginConfig(config: [BroadpeakMediaEntryInterceptor.pluginName: bpConfig])

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ var kalturaOTTPlayer: KalturaOTTPlayer
 
 let bpConfig = BroadpeakConfig()
 bpConfig.analyticsAddress = ""
-bpConfig.nanoCDNHost = "cdnapisec.kaltura.com"
+// Set nanoCDNHost only if you are using the Broadpeak nanoCDN device, othervise set an empty string ""
+bpConfig.nanoCDNHost = ""
 bpConfig.broadpeakDomainNames = "*"
 
 // Add PluginConfig to KalturaPlayer


### PR DESCRIPTION
Solves FEC-11180

nanoCDNHost argument should be set to an empty string.
This argument has to be set only if the project is using the Broadpeak nanoCDN device.