### PR TITLE
FEC-11667 - send InterceptorEvent.sourceUrlSwitched event once BP SDK returns with new URL

### DIFF
--- a/Example/playkit-ios-broadpeak/PlayerViewController.swift
+++ b/Example/playkit-ios-broadpeak/PlayerViewController.swift
@@ -78,6 +78,7 @@ class PlayerViewController: UIViewController {
         
         kalturaOTTPlayer.removeObserver(self, events: KPPlayerEvent.allEventTypes)
         kalturaOTTPlayer.removeObserver(self, events: BroadpeakEvent.allEventTypes)
+        kalturaOTTPlayer.removeObserver(self, events: InterceptorEvent.allEventTypes)
     }
     
     private func mediaOptions() -> OTTMediaOptions {
@@ -117,6 +118,18 @@ class PlayerViewController: UIViewController {
     
     private func registerPlayerEvents() {
         handleError()
+        
+        kalturaOTTPlayer.addObserver(self, events: [InterceptorEvent.sourceUrlSwitched]) { [weak self] event in
+            
+            if let event = event as? InterceptorEvent.SourceUrlSwitched,
+               let originalUrl = event.originalUrl,
+               let updatedUrl = event.updatedUrl {
+                
+                PKLog.debug("InterceptorEvent.sourceUrlSwitched originalUrl :: \(originalUrl)")
+                PKLog.debug("InterceptorEvent.sourceUrlSwitched updatedUrl:: \(updatedUrl)")
+            }
+        }
+
     }
     
     private func handleError() {
@@ -145,7 +158,5 @@ class PlayerViewController: UIViewController {
                 }
             }
         }
-        
     }
-    
 }

--- a/PlayKitBroadpeak/Classes/BroadpeakMediaEntryInterceptor.swift
+++ b/PlayKitBroadpeak/Classes/BroadpeakMediaEntryInterceptor.swift
@@ -128,7 +128,7 @@ extension BroadpeakMediaEntryInterceptor: PKMediaEntryInterceptor {
                     } else {
                         if let url = URL(string: result.getURL()) {
                             //send SourceUrlSwitched event
-                            self?.messageBus?.post(InterceptorEvent.SourceUrlSwitched(originalUrl: contentURL.absoluteString,                                                               updatedUrl: url.absoluteString))
+                            self?.messageBus?.post(InterceptorEvent.SourceUrlSwitched(originalUrl: contentURL.absoluteString, updatedUrl: url.absoluteString))
                             source.contentUrl = url
                         } else {
                             self?.streamingSession?.stop()

--- a/PlayKitBroadpeak/Classes/BroadpeakMediaEntryInterceptor.swift
+++ b/PlayKitBroadpeak/Classes/BroadpeakMediaEntryInterceptor.swift
@@ -89,7 +89,6 @@ import KalturaPlayer
         
         super.destroy()
     }
-    
 }
 
 extension BroadpeakMediaEntryInterceptor: PKMediaEntryInterceptor {
@@ -128,6 +127,8 @@ extension BroadpeakMediaEntryInterceptor: PKMediaEntryInterceptor {
                         self?.messageBus?.post(BroadpeakEvent.Error(error: BroadpeakPluginError.smartLibError(Int(result.getErrorCode()), result.getErrorMessage())))
                     } else {
                         if let url = URL(string: result.getURL()) {
+                            //send SourceUrlSwitched event
+                            self?.messageBus?.post(InterceptorEvent.SourceUrlSwitched(originalUrl: contentURL.absoluteString,                                                               updatedUrl: url.absoluteString))
                             source.contentUrl = url
                         } else {
                             self?.streamingSession?.stop()


### PR DESCRIPTION
sourceUrlSwitched event will contain originalUrl and the updatedUrl
app can use it for any need it finds.